### PR TITLE
Refresh floating LFO FX clone editor when switching presets

### DIFF
--- a/Main/uiRefresh.js
+++ b/Main/uiRefresh.js
@@ -716,4 +716,9 @@ function updateLfoInspector(){
     paramSel.appendChild(op);
     paramSel.value = bind.param || "mix";
   }
+
+  // If the floating clone editor is open, keep it in sync when switching presets.
+  if(window.__lfoFxCloneState?.open){
+    try{ _updateLfoFxCloneWindow(); }catch(_e){}
+  }
 }


### PR DESCRIPTION
### Motivation
- Fix the floating FX clone editor staying on the last-edited preset instead of updating when selecting a different `lfo_preset`, so the clone UI stays in sync with the inspector.

### Description
- When `updateLfoInspector()` runs, if the floating clone window is open (`window.__lfoFxCloneState.open`), call `_updateLfoFxCloneWindow()` inside a `try/catch` to refresh the clone UI.
- Change made in `Main/uiRefresh.js` (small insertion to keep clone editor synchronized with inspector updates).

### Testing
- No automated tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988463cd220832e8bc8af4506168523)