### PR TITLE
Use LFO preset snapshots for FX overrides and keep floating LFO clone UI in sync

### DIFF
--- a/Main/scheduler.js
+++ b/Main/scheduler.js
@@ -125,8 +125,13 @@ function __applyLfoPresetFxOverrides(songStep){
       }
 
       // build override state
-      const enabled = (bind.enabled != null) ? !!bind.enabled : (pat.preset?.enabled != null ? !!pat.preset.enabled : true);
-      const params = (bind.params && typeof bind.params==="object") ? bind.params : (pat.preset?.params || {});
+      const snapshot = pat.preset?.snapshot || null;
+      const enabled = (bind.enabled != null)
+        ? !!bind.enabled
+        : (snapshot?.enabled != null ? !!snapshot.enabled : (pat.preset?.enabled != null ? !!pat.preset.enabled : true));
+      const params = (bind.params && typeof bind.params==="object")
+        ? bind.params
+        : ((snapshot && typeof snapshot.params === "object") ? snapshot.params : (pat.preset?.params || {}));
 
       // signature to avoid redundant apply
       const sig = JSON.stringify({enabled, params});

--- a/Main/uiRefresh.js
+++ b/Main/uiRefresh.js
@@ -716,4 +716,9 @@ function updateLfoInspector(){
     paramSel.appendChild(op);
     paramSel.value = bind.param || "mix";
   }
+
+  // If the floating clone editor is open, keep it in sync when switching presets.
+  if(window.__lfoFxCloneState?.open){
+    try{ _updateLfoFxCloneWindow(); }catch(_e){}
+  }
 }


### PR DESCRIPTION
### Motivation
- Playlist LFO presets were not taking priority when applied to mixer FX, causing mixer table parameters to be used instead of the preset snapshot values.
- FX override resolution needs to prefer explicit clip binds, then the LFO preset snapshot, then legacy preset fields to preserve intended runtime overrides.
- The floating LFO clone editor must refresh when switching presets so the clone UI stays synchronized with the inspector.

### Description
- In `Main/scheduler.js`, `__applyLfoPresetFxOverrides` now reads `pat.preset.snapshot` and prefers `snapshot.params` and `snapshot.enabled` when a clip is active, while still allowing `bind` to override those values, before falling back to `pat.preset` fields.
- The override `sig` logic and `__lfoRT` bookkeeping are preserved so redundant `ae.applyMixerModel` calls are avoided when nothing changes.
- In `Main/uiRefresh.js`, when `window.__lfoFxCloneState?.open` is true the code now calls `_updateLfoFxCloneWindow()` inside a `try/catch` to refresh the floating clone editor when switching presets.

### Testing
- No automated tests were executed for these UI/logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988463cd220832e8bc8af4506168523)