### PR TITLE
Apply LFO preset snapshot params as full FX override and refresh floating LFO clone UI

### DIFF
--- a/Main/scheduler.js
+++ b/Main/scheduler.js
@@ -125,14 +125,20 @@ function __applyLfoPresetFxOverrides(songStep){
       }
 
       // build override state
-      const enabled = (bind.enabled != null) ? !!bind.enabled : (pat.preset?.enabled != null ? !!pat.preset.enabled : true);
-      const params = (bind.params && typeof bind.params==="object") ? bind.params : (pat.preset?.params || {});
+      const snapshot = pat.preset?.snapshot || null;
+      const enabled = (bind.enabled != null)
+        ? !!bind.enabled
+        : (snapshot?.enabled != null ? !!snapshot.enabled : (pat.preset?.enabled != null ? !!pat.preset.enabled : true));
+      const params = (bind.params && typeof bind.params==="object")
+        ? bind.params
+        : ((snapshot && typeof snapshot.params === "object") ? snapshot.params : (pat.preset?.params || {}));
 
       // signature to avoid redundant apply
       const sig = JSON.stringify({enabled, params});
       if(__lfoRT.lastSig.get(key) !== sig){
         fx.enabled = enabled;
-        fx.params = { ...(fx.params||{}), ...(params||{}) };
+        // LFO preset should drive full FX state, not merge with mixer table params.
+        fx.params = { ...(params||{}) };
         __lfoRT.lastSig.set(key, sig);
 
         // push to audio engine (only when changes)

--- a/Main/uiRefresh.js
+++ b/Main/uiRefresh.js
@@ -716,4 +716,9 @@ function updateLfoInspector(){
     paramSel.appendChild(op);
     paramSel.value = bind.param || "mix";
   }
+
+  // If the floating clone editor is open, keep it in sync when switching presets.
+  if(window.__lfoFxCloneState?.open){
+    try{ _updateLfoFxCloneWindow(); }catch(_e){}
+  }
 }


### PR DESCRIPTION
### Motivation
- Playlist LFO preset snapshot values were not taking precedence and mixer table parameters were being merged into FX state instead of the preset-driven values.
- FX override resolution must allow explicit clip binds to override, otherwise an active LFO preset snapshot should drive the FX state to reproduce playlist-programmed behavior.
- The floating LFO clone editor could fall out of sync when switching presets and needs to refresh to reflect inspector changes.

### Description
- In `Main/scheduler.js` read `pat.preset?.snapshot` and prefer `bind` then `snapshot` then legacy `pat.preset` when building the override `params` and `enabled` state.
- Change FX application so preset params replace the mixer FX params (set `fx.params = { ...(params||{}) }`) instead of merging with existing mixer table params, while preserving the `sig` check and `__lfoRT` bookkeeping to avoid redundant `ae.applyMixerModel` calls.
- In `Main/uiRefresh.js` add a guarded refresh call to `_updateLfoFxCloneWindow()` when `window.__lfoFxCloneState?.open` to keep the floating clone editor synchronized with inspector preset changes.

### Testing
- No automated tests were executed for these changes (logic/UI update only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988463cd220832e8bc8af4506168523)