### PR TITLE
Apply LFO preset FX overrides outside song mode and apply to cloned mixer

### DIFF
--- a/Main/scheduler.js
+++ b/Main/scheduler.js
@@ -16,9 +16,7 @@ const pb = {
 };
 // ---------------- LFO preset runtime override (non-destructive) ----------------
 const __lfoRT = {
-  // key -> { enabled, params } original snapshot to restore when LFO not active
-  orig: new Map(),
-  // key -> last applied signature to avoid redundant applyMixerModel
+  // last applied signature to avoid redundant applyMixerModel
   lastSig: new Map(),
 };
 
@@ -27,59 +25,26 @@ function __fxKey(scope, chIndex1, fxIndex){
   return `${s}:fx${fxIndex||0}`;
 }
 
-// Restore any FX not overridden on this tick
-function __lfoRestoreMissing(activeKeys){
-  for(const [key, snap] of __lfoRT.orig.entries()){
-    if(activeKeys.has(key)) continue;
-    const info = __lfoDecodeKey(key);
-    if(!info) continue;
-    const fx = __getMixerFx(info.scope, info.chIndex1, info.fxIndex);
-    if(!fx) continue;
-    // restore
-    if(snap.enabled != null) fx.enabled = snap.enabled;
-    if(snap.params && typeof snap.params === "object"){
-      fx.params = { ...snap.params };
-    }
-    __lfoRT.lastSig.delete(key);
-    __lfoRT.orig.delete(key);
-  }
-}
-
-function __lfoDecodeKey(key){
-  // "master:fx0" or "ch2:fx1"
+function __getMixerFx(scope, chIndex1, fxIndex, mix){
   try{
-    const [a,b] = key.split(":");
-    const fxIndex = parseInt((b||"fx0").replace("fx",""),10)||0;
-    if(a==="master") return {scope:"master", chIndex1:1, fxIndex};
-    const m = /^ch(\d+)$/.exec(a||"");
-    if(!m) return null;
-    return {scope:"channel", chIndex1: parseInt(m[1],10)||1, fxIndex};
-  }catch(_){ return null; }
-}
-
-function __getMixerFx(scope, chIndex1, fxIndex){
-  try{
+    const source = mix || project.mixer;
     const isMaster = (scope||"").toLowerCase()==="master";
-    const list = isMaster ? (project.mixer?.master?.fx||[]) : ((project.mixer?.channels||[])[Math.max(0,(chIndex1||1)-1)]?.fx||[]);
+    const list = isMaster ? (source?.master?.fx||[]) : ((source?.channels||[])[Math.max(0,(chIndex1||1)-1)]?.fx||[]);
     return list[fxIndex] || null;
   }catch(_){ return null; }
 }
 
-function __applyLfoPresetFxOverrides(songStep){
+function __applyLfoPresetFxOverrides(songStep, absStep){
   // Apply overrides aligned to playhead (no lookahead)
   if(!state.playing) return;
-  if(state.mode !== "song") return;
   if(!project || !project.playlist || !Array.isArray(project.playlist.tracks)) return;
 
-  const activeKeys = new Set();
+  const overrides = [];
 
-  const stepInSong = songStep; // ensure defined (fixes ReferenceError)
+  const stepInSong = (state.mode === "song") ? songStep : (absStep ?? songStep);
   const spb = state.stepsPerBar;
 
   for(const tr of project.playlist.tracks){
-    const ttype = (tr.type||"").toString().toLowerCase();
-    if(ttype !== "lfo") continue;
-
     for(const clip of (tr.clips||[])){
       const pat = project.patterns.find(p => p.id === clip.patternId);
       if(!pat) continue;
@@ -98,10 +63,16 @@ function __applyLfoPresetFxOverrides(songStep){
       if(scope === "master"){
         chIndex1 = 1;
       }else{
-        // prefer explicit bind.channelId (numeric mixer channel index1)
+        // prefer explicit bind.channelId (numeric mixer channel index1 or mixer channel id)
         const explicit = Number(bind.channelId);
-        if(Number.isFinite(explicit) && explicit > 0) chIndex1 = Math.floor(explicit);
-        else{
+        if(Number.isFinite(explicit) && explicit > 0){
+          chIndex1 = Math.floor(explicit);
+        }else if(bind.channelId){
+          const idx = (project.mixer?.channels || []).findIndex(c => String(c.id) === String(bind.channelId));
+          if(idx >= 0) chIndex1 = idx + 1;
+        }
+
+        if(!chIndex1){
           // fallback: current active instrument channel mixOut
           try{
             const ac = (typeof activeChannel==="function") ? activeChannel() : null;
@@ -113,37 +84,55 @@ function __applyLfoPresetFxOverrides(songStep){
       const fxIndex = Math.max(0, Math.floor(bind.fxIndex||0));
       const key = __fxKey(scope, chIndex1, fxIndex);
 
-      const fx = __getMixerFx(scope==="master"?"master":"channel", chIndex1, fxIndex);
-      if(!fx) continue;
-
-      // snapshot original once
-      if(!__lfoRT.orig.has(key)){
-        __lfoRT.orig.set(key, {
-          enabled: fx.enabled,
-          params: fx.params ? { ...fx.params } : {}
-        });
-      }
-
       // build override state
-      const enabled = (bind.enabled != null) ? !!bind.enabled : (pat.preset?.enabled != null ? !!pat.preset.enabled : true);
-      const params = (bind.params && typeof bind.params==="object") ? bind.params : (pat.preset?.params || {});
+      const snapshot = pat.preset?.snapshot || null;
+      const enabled = (bind.enabled != null)
+        ? !!bind.enabled
+        : (snapshot?.enabled != null ? !!snapshot.enabled : (pat.preset?.enabled != null ? !!pat.preset.enabled : true));
+      const params = (bind.params && typeof bind.params==="object")
+        ? bind.params
+        : ((snapshot && typeof snapshot.params === "object") ? snapshot.params : (pat.preset?.params || {}));
 
-      // signature to avoid redundant apply
-      const sig = JSON.stringify({enabled, params});
-      if(__lfoRT.lastSig.get(key) !== sig){
-        fx.enabled = enabled;
-        fx.params = { ...(fx.params||{}), ...(params||{}) };
-        __lfoRT.lastSig.set(key, sig);
-
-        // push to audio engine (only when changes)
-        try{ if(ae && ae.applyMixerModel) ae.applyMixerModel(project.mixer); }catch(_){}
-      }
-
-      activeKeys.add(key);
+      overrides.push({
+        key,
+        scope,
+        chIndex1,
+        fxIndex,
+        enabled,
+        params: params || {}
+      });
     }
   }
 
-  __lfoRestoreMissing(activeKeys);
+  if(!overrides.length){
+    if(__lfoRT.lastSig.get("mix") !== "base"){
+      try{ if(ae && ae.applyMixerModel) ae.applyMixerModel(project.mixer); }catch(_){}
+      __lfoRT.lastSig.set("mix", "base");
+    }
+    return;
+  }
+
+  const sig = JSON.stringify(overrides.map(o=>({
+    key:o.key,
+    enabled:o.enabled,
+    params:o.params
+  })).sort((a,b)=>String(a.key).localeCompare(String(b.key))));
+
+  if(__lfoRT.lastSig.get("mix") === sig) return;
+
+  const mixClone = (typeof structuredClone === "function")
+    ? structuredClone(project.mixer)
+    : JSON.parse(JSON.stringify(project.mixer));
+
+  for(const ov of overrides){
+    const fx = __getMixerFx(ov.scope==="master"?"master":"channel", ov.chIndex1, ov.fxIndex, mixClone);
+    if(!fx) continue;
+    fx.enabled = ov.enabled;
+    fx.params = { ...(ov.params||{}) };
+  }
+
+  __lfoRT.lastSig.set("mix", sig);
+  try{ if(ae && ae.applyMixerModel) ae.applyMixerModel(mixClone); }catch(_){}
 }
 function _recalcEndStepForMode(){
   try{
@@ -335,7 +324,7 @@ function tick() {
   pb.uiSongStep = uiStep;
 
   // LFO preset overrides must be aligned to playhead (NOT scheduling lookahead)
-  try{ __applyLfoPresetFxOverrides(pb.uiSongStep); }catch(_){ }
+  try{ __applyLfoPresetFxOverrides(pb.uiSongStep, pb.uiAbsStep); }catch(_){ }
 
 
   try {

--- a/Main/uiRefresh.js
+++ b/Main/uiRefresh.js
@@ -716,4 +716,9 @@ function updateLfoInspector(){
     paramSel.appendChild(op);
     paramSel.value = bind.param || "mix";
   }
+
+  // If the floating clone editor is open, keep it in sync when switching presets.
+  if(window.__lfoFxCloneState?.open){
+    try{ _updateLfoFxCloneWindow(); }catch(_e){}
+  }
 }


### PR DESCRIPTION
### Motivation
- Ensure playlist LFO preset overrides are applied to the targeted mixer FX even when the player is not in `song` mode by aligning overrides to the absolute playhead step and avoiding direct mutation of the live mixer model.

### Description
- Change `__applyLfoPresetFxOverrides` signature to accept an `absStep` and compute `stepInSong` using `state.mode === "song" ? songStep : (absStep ?? songStep)` so overrides run outside song mode.
- Collect override entries, compute a deterministic signature, and short-circuit when nothing changed to avoid redundant work.
- Clone `project.mixer` (using `structuredClone` with a JSON fallback), apply the override values into the clone, and call `ae.applyMixerModel(mixClone)` so the audio engine receives a temporary overridden mixer without mutating the canonical model.
- Add an optional `mix` parameter to `__getMixerFx` so FX lookups can resolve inside the cloned mixer, and remove the older per-FX snapshot/restore code in favor of the clone+signature approach.
- Keep the LFO clone editor UI in sync by calling `_updateLfoFxCloneWindow()` when the floating clone editor is open in `updateLfoInspector` in `uiRefresh.js`.

### Testing
- No automated tests were executed for this change because it is a logic-only scheduler/UI update.
- The change was committed locally and is a minimal refactor to override application and mixer cloning logic; no runtime regressions were verified by automated test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988463cd220832e8bc8af4506168523)