### PR TITLE
Smart playback range, loop-scope UI, and LFO/channel editor fixes

### DIFF
--- a/Main/saveLoad.js
+++ b/Main/saveLoad.js
@@ -90,6 +90,7 @@ function importProject(data){
 
   buildAllTimelines();
   refreshUI();
+  try{ if(typeof reloadLfoBindEditorFromPlaylist === "function") reloadLfoBindEditorFromPlaylist(); }catch(_){ }
   renderAll();
   try{ renderMixerUI(); }catch(_){}
   try{ if(ae && ae.ctx && ae.mixer){ ae.applyMixerModel(project.mixer); } }catch(_){}

--- a/Main/wiring.js
+++ b/Main/wiring.js
@@ -1,3 +1,14 @@
+
+function updateLoopButtonLabel(){
+  const hasSel = (typeof getTimeRulerSelectionSteps === "function") && (
+    ((getTimeRulerSelectionSteps("playlist")||{}).endStep||0) > ((getTimeRulerSelectionSteps("playlist")||{}).startStep||0) ||
+    ((getTimeRulerSelectionSteps("roll")||{}).endStep||0) > ((getTimeRulerSelectionSteps("roll")||{}).startStep||0)
+  );
+  const scope = hasSel ? "SEG" : ((state.mode==="song") ? "SONG" : "PAT");
+  loopBtn.textContent = `🔁 Loop ${scope}`;
+  loopBtn.classList.toggle("active", !!state.loop);
+}
+
 /* ================= Electro DAW | wiring.js ================= */
 /* ---------------- wiring buttons ---------------- */
 toolPaint.addEventListener("click",()=>setTool("paint"));
@@ -11,7 +22,10 @@ bpm.addEventListener("change",()=>{
 
 playBtn.addEventListener("click", async ()=>{ if(!state.playing) await start(); else pause(); });
 stopBtn.addEventListener("click", stop);
-loopBtn.addEventListener("click",()=>{ state.loop=!state.loop; loopBtn.classList.toggle("active",state.loop); });
+loopBtn.addEventListener("click",()=>{ state.loop=!state.loop; updateLoopButtonLabel(); });
+window.addEventListener("timeRulerSelectionChanged", updateLoopButtonLabel);
+window.addEventListener("daw:refresh", updateLoopButtonLabel);
+updateLoopButtonLabel();
 
 vel.addEventListener("input",()=> velVal.textContent=vel.value);
 


### PR DESCRIPTION
### Motivation
- Make playback smarter so timeline selections (playlist or roll) can be played as a segment instead of always the full song or pattern. 
- Improve loop button UX to clearly show whether loop applies to a selected segment, the full song or a pattern. 
- Restore LFO/preset binding state when loading projects so editors/inspectors rehydrate and remain functional, and add useful channel context actions (rename, color, delete).

### Description
- Added range-aware playback to the scheduler by introducing `pb.rangeStartStep`, `pb.rangeEndStep`, `_selectedRangeSteps()` and wiring `start()`, `tick()` and `_recalcEndStepForMode()` to schedule and display using the selected range. 
- Updated the transport UI with `updateLoopButtonLabel()` so the Loop button text reflects scope (`SEG` / `SONG` / `PAT`) and wired it to `timeRulerSelectionChanged` and `daw:refresh` events. 
- Added `reloadLfoBindEditorFromPlaylist()` to `uiRefresh.js` and call it after project import to rehydrate `lfo_curve`/`lfo_preset` bind/preset structures and refresh LFO inspectors/editors. 
- Implemented a right-click context menu for channel rows (`openChannelContextMenu`) to rename channels, change note color, and delete instruments; replaced the old rename-on-right-click with this menu. 
- Files changed: `Main/scheduler.js`, `Main/wiring.js`, `Main/uiRefresh.js`, `Main/saveLoad.js`.

### Testing
- Ran syntax checks: `node --check Main/scheduler.js && node --check Main/wiring.js && node --check Main/uiRefresh.js && node --check Main/saveLoad.js` (all succeeded). 
- Attempted a headless UI render / screenshot via Playwright which failed to load `file:///.../Main/index.html` in this environment (noted as an environment limitation, not a code error). 
- Changes were committed with message `Add smart timeline playback and LFO bind/UI context improvements`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b455eafcc832e83c4d5e2d9a3c57d)