### PR TITLE
Restore LFO backup files and keep fixes scoped to Main

### DIFF
--- a/Main/scheduler.js
+++ b/Main/scheduler.js
@@ -244,7 +244,10 @@ function __applyLfoCurveOverrides(songStep){
       const clipEndStep = clipStartStep + clipLenSteps;
       if(stepInSong < clipStartStep || stepInSong >= clipEndStep) continue;
 
-      const t = (stepInSong - clipStartStep) / clipLenSteps;
+      const patLenSteps = Math.max(1, patternLengthBars(pat) * spb);
+      const stepInClip = Math.max(0, stepInSong - clipStartStep);
+      const stepInPattern = stepInClip % patLenSteps;
+      const t = stepInPattern / patLenSteps;
       const lfoVal = __lfoCurveSample(pat, t);
 
       const bind = pat.bind || {};

--- a/Main/uiRefresh.js
+++ b/Main/uiRefresh.js
@@ -781,7 +781,9 @@ function updateLfoInspector(){
 
   const bind = isPreset ? (p.preset||{}) : (p.bind||{});
   const scope = bind.scope || "channel";
+  const patLen = Math.max(1, Math.min(8, parseInt(p.lenBars,10) || 4));
   _safeSetSelectValue(scopeSel, scope, "channel");
+  _safeSetSelectValue(lenSel, String(patLen), "4");
 
   _safeSetSelectValue(chSel, (scope==="master") ? "" : (bind.channelId||""), "");
 


### PR DESCRIPTION
### Motivation

- The reference backup in `old_ filefor-logic-lfo` was unintentionally modified and must be restored so it remains a reliable working reference for LFO logic.
- Runtime fixes for correct pattern-local LFO looping and inspector sync should remain applied only in `Main/` so the backup is not altered.

### Description

- Reverted `old_ filefor-logic-lfo/scheduler.js` to the previous behavior where `t` is computed as clip-normalized time (`(stepInSong - clipStartStep) / clipLenSteps`).
- Reverted `old_ filefor-logic-lfo/uiRefresh.js` to remove the forced `lfoPatternLen` inspector synchronization and restore the original UI state.
- Kept and scoped the intended runtime fixes in `Main/`, which include pattern-local LFO looping logic in `Main/scheduler.js` (computing `patLenSteps`, `stepInPattern`, and using `t = stepInPattern / patLenSteps`) and inspector length sync via `_safeSetSelectValue(lenSel, String(patLen), "4")` in `Main/uiRefresh.js`.
- Committed the restores with message `Restore old LFO backup files to pre-fix state` so the backup folder is again an accurate reference.

### Testing

- Ran `node --check "old_ filefor-logic-lfo/scheduler.js"` and it succeeded.
- Ran `node --check "old_ filefor-logic-lfo/uiRefresh.js"` and it succeeded.
- Ran `node --check Main/scheduler.js` and `node --check Main/uiRefresh.js` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb790ad58832e9d96b134a2b9b4a6)