### PR TITLE
Add Sampler Key library manager (Phase 1) with persistent folders and import flow

### DIFF
--- a/Main/index.html
+++ b/Main/index.html
@@ -245,6 +245,18 @@
   .autoStep.on{background:rgba(255,77,109,.25)}
   .autoLegend{font-size:11px;color:var(--muted);line-height:1.2}
 
+  .samplerLayout{display:grid;grid-template-columns:320px 1fr;gap:12px;padding:12px;height:calc(100% - 40px)}
+  .samplerSide,.samplerMain{min-height:0}
+  .samplerMain{display:grid;grid-template-rows:1fr auto;gap:12px}
+  .samplerBlock{background:rgba(0,0,0,.22);border:1px solid var(--line);border-radius:12px;padding:10px;display:flex;flex-direction:column;gap:8px;min-height:0}
+  .samplerList{display:flex;flex-direction:column;gap:6px;overflow:auto;min-height:0}
+  .samplerItem{padding:8px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.1);background:rgba(255,255,255,.04);cursor:pointer;font-size:12px;font-weight:700;display:flex;justify-content:space-between;align-items:center;gap:8px}
+  .samplerItem:hover{background:rgba(255,255,255,.08)}
+  .samplerItem.active{background:rgba(112,167,255,.22);border-color:rgba(112,167,255,.45)}
+  .samplerDropZone{border:2px dashed rgba(112,167,255,.45);border-radius:12px;padding:18px;text-align:center;color:var(--muted);font-weight:800}
+  .samplerDropZone.dragover{border-color:var(--accent);color:var(--accent);background:rgba(39,224,163,.08)}
+
+
 </style>
 </head>
 <body>
@@ -446,8 +458,32 @@
 
 
     <div class="view" id="view-sampler">
-      <div class="viewhead"><div class="headleft"><div class="small">Sampler (stub)</div></div></div>
-      <div style="padding:14px" class="small">Waveform + loop start/end + base note à venir.</div>
+      <div class="viewhead"><div class="headleft"><div class="small">Sampler Key — Bibliothèque</div></div></div>
+      <div class="samplerLayout">
+        <aside class="samplerSide">
+          <div class="samplerBlock">
+            <div class="title">📂 Dossiers sources</div>
+            <button class="btn2" id="samplerAddRoot">+ Ajouter dossier</button>
+            <button class="btn2" id="samplerRescan">↻ Rescanner</button>
+            <div class="small">Chemins persistés localement pour éviter de les reconfigurer à chaque démarrage.</div>
+            <div id="samplerRoots" class="samplerList"></div>
+          </div>
+        </aside>
+        <section class="samplerMain">
+          <div class="samplerBlock">
+            <div class="title">🗂️ Browser samples</div>
+            <div class="small" id="samplerRootLabel">Aucun dossier sélectionné</div>
+            <div id="samplerBrowser" class="samplerList"></div>
+          </div>
+          <div class="samplerBlock">
+            <div class="title">🎧 Pré-écoute et import</div>
+            <div class="small" id="samplerSelectedName">Sélectionnez un sample pour pré-écoute.</div>
+            <audio id="samplerPreview" controls preload="none" style="width:100%;margin:10px 0 12px"></audio>
+            <div id="samplerDropZone" class="samplerDropZone">Glissez-déposez un sample ici pour l'import Sampler Key.</div>
+            <div class="small" id="samplerDropStatus" style="margin-top:8px">Aucun sample importé.</div>
+          </div>
+        </section>
+      </div>
     </div>
   </div>
 
@@ -537,6 +573,7 @@
 <script defer src="./mixer.js"></script>
   <script defer src="./wiring.js"></script>
 <script defer src="./renderHelpers.js"></script>
+<script defer src="./sampleDirectory.js"></script>
 <script defer src="./sampler.js"></script>
 <script defer src="./demoSeed.js"></script>
 <script defer src="./boot.js"></script>

--- a/Main/preload.js
+++ b/Main/preload.js
@@ -8,3 +8,8 @@ contextBridge.exposeInMainWorld("audioNative", {
     return () => ipcRenderer.removeListener("audio:native:event", handler);
   }
 });
+
+contextBridge.exposeInMainWorld("samplerFS", {
+  pickDirectories: () => ipcRenderer.invoke("sampler:pickDirectories"),
+  scanDirectories: (directories) => ipcRenderer.invoke("sampler:scanDirectories", { directories }),
+});

--- a/Main/sampleDirectory.js
+++ b/Main/sampleDirectory.js
@@ -1,13 +1,131 @@
 /* ================= Electro DAW | samplerDirectory.js ================= */
 /* ---------------- sample bank Manager includ---------------- */
-/** DIRECTORY CONFIG: Defines and persists the root folder paths for the sample library within the system configuration **/
+(function initSampleDirectory(global) {
+  const STORAGE_KEY = "sls.sampler.roots.v1";
 
-/** LIBRARY SCANNER: Recursively scans designated directories to index supported audio files like .wav, .mp3, and .ogg **/
+  const directoryState = {
+    roots: [],
+    activeRootPath: null,
+    selectedSample: null,
+    importedSample: null,
+    dragSample: null,
+  };
 
-/** BROWSER UI: Renders the file tree structure and handles user navigation through the sample directories **/
+  function saveRootsToStorage() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(directoryState.roots.map((r) => r.rootPath)));
+    } catch (error) {
+      console.warn("[SamplerDirectory] localStorage write failed:", error);
+    }
+  }
 
-/** PREVIEW PLAYER: Handles low-latency audio playback for samples selected in the browser before they are imported **/
+  function loadRootPathsFromStorage() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string" && x.length > 0) : [];
+    } catch (error) {
+      console.warn("[SamplerDirectory] localStorage parse failed:", error);
+      return [];
+    }
+  }
 
-/** FILE WATCHER: Monitors selected directories for real-time changes, such as newly added or deleted sample files **/
+  async function pickRootDirectories() {
+    if (!global.samplerFS?.pickDirectories) {
+      return { ok: false, error: "samplerFS indisponible dans ce contexte." };
+    }
+    return global.samplerFS.pickDirectories();
+  }
 
-/** METADATA CACHE: Stores and retrieves analyzed sample data to avoid redundant pitch detection on previously scanned files **/
+  async function scanRoots(rootPaths) {
+    if (!global.samplerFS?.scanDirectories) {
+      return { ok: false, error: "scanDirectories indisponible." };
+    }
+    return global.samplerFS.scanDirectories(rootPaths);
+  }
+
+  async function restorePersistedRoots() {
+    const savedPaths = loadRootPathsFromStorage();
+    if (!savedPaths.length) return { ok: true, roots: [] };
+    return rescanWithPaths(savedPaths);
+  }
+
+  async function rescanWithPaths(paths) {
+    const result = await scanRoots(paths);
+    if (!result?.ok) return result;
+
+    directoryState.roots = result.roots || [];
+    if (!directoryState.roots.find((root) => root.rootPath === directoryState.activeRootPath)) {
+      directoryState.activeRootPath = directoryState.roots[0]?.rootPath || null;
+    }
+    saveRootsToStorage();
+    emitChange();
+    return { ok: true, roots: directoryState.roots };
+  }
+
+  async function addRootsFromDialog() {
+    const picked = await pickRootDirectories();
+    if (!picked?.ok) return picked || { ok: false, error: "Sélection annulée." };
+
+    const currentPaths = directoryState.roots.map((root) => root.rootPath);
+    const unique = [...new Set([...currentPaths, ...(picked.directories || [])])];
+    return rescanWithPaths(unique);
+  }
+
+  async function rescanCurrentRoots() {
+    const paths = directoryState.roots.map((root) => root.rootPath);
+    if (!paths.length) return { ok: true, roots: [] };
+    return rescanWithPaths(paths);
+  }
+
+  function setActiveRoot(rootPath) {
+    directoryState.activeRootPath = rootPath;
+    emitChange();
+  }
+
+  function selectSample(sample) {
+    directoryState.selectedSample = sample || null;
+    emitChange();
+  }
+
+  function setDragSample(sample) {
+    directoryState.dragSample = sample || null;
+  }
+
+  function importSample(sample) {
+    directoryState.importedSample = sample || null;
+    emitChange();
+  }
+
+  function getActiveRoot() {
+    return directoryState.roots.find((root) => root.rootPath === directoryState.activeRootPath) || null;
+  }
+
+  function emitChange() {
+    global.dispatchEvent(new CustomEvent("sampler-directory:change", { detail: getSnapshot() }));
+  }
+
+  function getSnapshot() {
+    return {
+      roots: directoryState.roots,
+      activeRootPath: directoryState.activeRootPath,
+      activeRoot: getActiveRoot(),
+      selectedSample: directoryState.selectedSample,
+      importedSample: directoryState.importedSample,
+      dragSample: directoryState.dragSample,
+    };
+  }
+
+  global.sampleDirectory = {
+    state: directoryState,
+    restorePersistedRoots,
+    addRootsFromDialog,
+    rescanCurrentRoots,
+    setActiveRoot,
+    selectSample,
+    setDragSample,
+    importSample,
+    getSnapshot,
+  };
+})(window);

--- a/Main/sampler.js
+++ b/Main/sampler.js
@@ -1,13 +1,193 @@
 /* ================= Electro DAW | sampler.js ================= */
 /* name of custom Sampler is Saple To Key includ . */
-/** ANALYSIS: Detects the fundamental frequency (Hz) and identifies the Root Key with semitones of the imported sample **/
+(function initSamplerLibraryUI(global) {
+  const directory = global.sampleDirectory;
+  if (!directory) return;
 
-/** INTERPOLATION: Calculates the playback rate ratio to map the sample across the Piano Roll keys based on the Root Key **/
+  const rootsEl = document.getElementById("samplerRoots");
+  const browserEl = document.getElementById("samplerBrowser");
+  const rootLabelEl = document.getElementById("samplerRootLabel");
+  const selectedNameEl = document.getElementById("samplerSelectedName");
+  const previewEl = document.getElementById("samplerPreview");
+  const dropZoneEl = document.getElementById("samplerDropZone");
+  const dropStatusEl = document.getElementById("samplerDropStatus");
+  const addRootBtn = document.getElementById("samplerAddRoot");
+  const rescanBtn = document.getElementById("samplerRescan");
 
-/** SUSTAIN: Defines the Loop Start and Loop End points to create a continuous sound during long note presses **/
+  function makeItemLabel(sample) {
+    const rel = sample.relativePath || sample.name;
+    return rel.length > 56 ? `${rel.slice(0, 53)}...` : rel;
+  }
 
-/** VISUAL RENDERING: Draws the sample waveform on canvas including interactive markers for playback, loop, and sustain **/
+  function sampleToPreviewUrl(sample) {
+    if (!sample?.path) return "";
+    const normalized = sample.path.replace(/\\/g, "/");
+    return `file://${encodeURI(normalized)}`;
+  }
 
-/** AUDIO ENGINE: Triggers the interpolated audio signal and routes it in real-time to the centralized Mixer Engine **/
+  function setStatus(message) {
+    if (dropStatusEl) dropStatusEl.textContent = message;
+  }
 
-/** CROSSFADE: Applies a smooth fade-in/out at loop points to eliminate audible clicks during sustain cycles **/
+  function renderRoots(snapshot) {
+    if (!rootsEl) return;
+    rootsEl.innerHTML = "";
+    if (!snapshot.roots.length) {
+      rootsEl.innerHTML = '<div class="small">Aucun dossier configuré.</div>';
+      return;
+    }
+
+    for (const root of snapshot.roots) {
+      const btn = document.createElement("button");
+      btn.className = "samplerItem" + (root.rootPath === snapshot.activeRootPath ? " active" : "");
+      btn.type = "button";
+      btn.innerHTML = `<span>${root.rootName}</span><span class="small">${root.files.length}</span>`;
+      btn.title = root.rootPath;
+      btn.addEventListener("click", () => directory.setActiveRoot(root.rootPath));
+      rootsEl.appendChild(btn);
+    }
+  }
+
+  function renderBrowser(snapshot) {
+    if (!browserEl || !rootLabelEl) return;
+    const activeRoot = snapshot.activeRoot;
+    browserEl.innerHTML = "";
+
+    if (!activeRoot) {
+      rootLabelEl.textContent = "Aucun dossier sélectionné";
+      browserEl.innerHTML = '<div class="small">Ajoutez un dossier pour indexer vos samples .wav/.mp3/.ogg.</div>';
+      return;
+    }
+
+    rootLabelEl.textContent = `${activeRoot.rootName} — ${activeRoot.files.length} samples indexés`;
+    if (!activeRoot.files.length) {
+      browserEl.innerHTML = '<div class="small">Aucun fichier supporté trouvé dans ce dossier.</div>';
+      return;
+    }
+
+    for (const sample of activeRoot.files) {
+      const item = document.createElement("div");
+      item.className = "samplerItem" + (snapshot.selectedSample?.path === sample.path ? " active" : "");
+      item.draggable = true;
+      item.innerHTML = `<span>${makeItemLabel(sample)}</span><span class="small">${sample.ext}</span>`;
+      item.title = sample.relativePath || sample.name;
+
+      item.addEventListener("click", () => {
+        directory.selectSample(sample);
+      });
+
+      item.addEventListener("dragstart", (event) => {
+        directory.setDragSample(sample);
+        event.dataTransfer.effectAllowed = "copy";
+        event.dataTransfer.setData("application/x-sls-sample", JSON.stringify(sample));
+        event.dataTransfer.setData("text/plain", sample.path);
+      });
+
+      browserEl.appendChild(item);
+    }
+  }
+
+  function renderPreview(snapshot) {
+    const selected = snapshot.selectedSample;
+    if (!selected) {
+      if (selectedNameEl) selectedNameEl.textContent = "Sélectionnez un sample pour pré-écoute.";
+      if (previewEl) {
+        previewEl.pause();
+        previewEl.removeAttribute("src");
+        previewEl.load();
+      }
+      return;
+    }
+
+    if (selectedNameEl) selectedNameEl.textContent = `Pré-écoute: ${selected.relativePath || selected.name}`;
+    if (previewEl) {
+      const newSrc = sampleToPreviewUrl(selected);
+      if (previewEl.src !== newSrc) {
+        previewEl.src = newSrc;
+        previewEl.load();
+      }
+    }
+  }
+
+  function renderImported(snapshot) {
+    const imported = snapshot.importedSample;
+    if (!imported) {
+      setStatus("Aucun sample importé.");
+      return;
+    }
+    setStatus(`Import prêt: ${imported.relativePath || imported.name} (analyse pitch: étape suivante).`);
+  }
+
+  function render(snapshot) {
+    renderRoots(snapshot);
+    renderBrowser(snapshot);
+    renderPreview(snapshot);
+    renderImported(snapshot);
+  }
+
+  async function withBusyButton(button, job) {
+    if (!button) return job();
+    const prev = button.textContent;
+    button.disabled = true;
+    button.textContent = "...";
+    try {
+      return await job();
+    } finally {
+      button.disabled = false;
+      button.textContent = prev;
+    }
+  }
+
+  addRootBtn?.addEventListener("click", async () => {
+    await withBusyButton(addRootBtn, async () => {
+      const result = await directory.addRootsFromDialog();
+      if (!result?.ok && !result?.canceled) {
+        setStatus(`Erreur ajout dossier: ${result?.error || "inconnue"}`);
+      }
+    });
+  });
+
+  rescanBtn?.addEventListener("click", async () => {
+    await withBusyButton(rescanBtn, async () => {
+      const result = await directory.rescanCurrentRoots();
+      if (!result?.ok) setStatus(`Erreur scan: ${result?.error || "inconnue"}`);
+    });
+  });
+
+  dropZoneEl?.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    dropZoneEl.classList.add("dragover");
+  });
+
+  dropZoneEl?.addEventListener("dragleave", () => {
+    dropZoneEl.classList.remove("dragover");
+  });
+
+  dropZoneEl?.addEventListener("drop", (event) => {
+    event.preventDefault();
+    dropZoneEl.classList.remove("dragover");
+
+    let sample = directory.state.dragSample;
+    const raw = event.dataTransfer.getData("application/x-sls-sample");
+    if (!sample && raw) {
+      try {
+        sample = JSON.parse(raw);
+      } catch (_error) {
+        sample = null;
+      }
+    }
+
+    if (!sample) {
+      setStatus("Drop invalide: glissez un sample depuis le Browser.");
+      return;
+    }
+
+    directory.importSample(sample);
+  });
+
+  global.addEventListener("sampler-directory:change", (event) => {
+    render(event.detail || directory.getSnapshot());
+  });
+
+  directory.restorePersistedRoots().then(() => render(directory.getSnapshot()));
+})(window);


### PR DESCRIPTION
### Motivation
- Provide an in-DAW Sampler Key library manager so users can register persistent folder roots, browse indexed samples and prepare imports for the pitch-analysis pipeline.
- Allow fast iteration without leaving the DAW by adding preview, drag-&-drop import, and a simple root/rescan workflow as the Phase 1 foundation for sampling features.

### Description
- Replaced the Sampler stub view with a new "Sampler Key — Bibliothèque" UI and styles in `Main/index.html` and ensured `sampleDirectory.js` is loaded before `sampler.js`.
- Implemented a recursive scanner and IPC in the main process: `scanSamplerDirectory` plus handlers `sampler:pickDirectories` and `sampler:scanDirectories` that index `.wav`, `.mp3` and `.ogg` files in `Main/main.js`.
- Exposed the filesystem IPC to the renderer via the preload bridge `window.samplerFS` in `Main/preload.js` with `pickDirectories` and `scanDirectories` methods.
- Added a renderer-side directory manager `Main/sampleDirectory.js` that persists root paths to `localStorage`, restores them on startup, performs rescans and emits `sampler-directory:change`, and added `Main/sampler.js` which renders roots/browser, handles selection, preview (HTML `<audio>`), drag start and drop import flow.

### Testing
- Ran syntax checks with `node --check` on updated files (`Main/main.js`, `Main/preload.js`, `Main/sampleDirectory.js`, `Main/sampler.js`) and they returned without errors (success).
- Attempted an automated Playwright screenshot by serving `Main` on a local HTTP server and navigating to the sampler view, but Playwright/Chromium crashed with a SIGSEGV in this environment so the screenshot step failed (known environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d07230f20832ea7821ddb41e7af36)