### PR TITLE
Add 4‑point Touski sampler editor and segmented playback state machine

### DIFF
--- a/Main/index.html
+++ b/Main/index.html
@@ -260,9 +260,12 @@
   .samplerMetric .small b{color:var(--text)}
   .samplerWave{position:relative}
   .samplerWave canvas{display:block;width:100%;height:140px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:#070b12}
-  .samplerLoopEditor{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
+  .samplerLoopEditor{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
   .samplerLoopEditor label{display:flex;flex-direction:column;gap:5px;font-size:11px;color:var(--muted)}
   .samplerLoopEditor input[type="range"]{width:100%}
+  .samplerLegend{display:flex;gap:10px;flex-wrap:wrap}
+  .samplerLegend span{display:inline-flex;align-items:center;gap:5px;font-size:11px;color:var(--muted)}
+  .samplerLegend i{width:10px;height:10px;border-radius:50%;display:inline-block}
   .samplerPianoMap{max-height:180px;overflow:auto;border:1px solid rgba(255,255,255,.08);border-radius:10px}
   .samplerPianoMap table{width:100%;border-collapse:collapse;font-size:11px}
   .samplerPianoMap th,.samplerPianoMap td{padding:6px 8px;border-bottom:1px solid rgba(255,255,255,.07);text-align:left}
@@ -504,15 +507,24 @@
             <div class="samplerWave">
               <canvas id="samplerWaveCanvas" width="900" height="140"></canvas>
             </div>
+            <div class="samplerLegend">
+              <span><i style="background:#d04cff"></i>Key Action</span>
+              <span><i style="background:#f5ea2f"></i>Start Loop</span>
+              <span><i style="background:#ff4b4b"></i>End Loop</span>
+              <span><i style="background:#36b7ff"></i>Release</span>
+            </div>
             <div class="samplerLoopEditor">
+              <label>Key Action
+                <input id="samplerPosAction" type="range" min="0" max="100" value="0">
+              </label>
               <label>Loop Start
                 <input id="samplerLoopStart" type="range" min="0" max="100" value="15">
               </label>
               <label>Loop End
                 <input id="samplerLoopEnd" type="range" min="0" max="100" value="90">
               </label>
-              <label>Sustain
-                <input id="samplerSustain" type="range" min="0" max="100" value="72">
+              <label>Release Point
+                <input id="samplerReleasePoint" type="range" min="0" max="100" value="100">
               </label>
             </div>
             <div class="small" id="samplerLoopStatus">Loop sustain editor prêt.</div>

--- a/Main/sampleDirectory.js
+++ b/Main/sampleDirectory.js
@@ -159,6 +159,14 @@
       sample: programData.sample || null,
       rootMidi: Number.isFinite(+programData.rootMidi) ? +programData.rootMidi : null,
       rootHz: Number.isFinite(+programData.rootHz) ? +programData.rootHz : null,
+      posAction: Number.isFinite(+programData.posAction) ? Math.max(0, Math.min(1, +programData.posAction)) : 0,
+      posLoopStart: Number.isFinite(+programData.posLoopStart)
+        ? Math.max(0, Math.min(1, +programData.posLoopStart))
+        : (Number.isFinite(+programData.loopStartPct) ? Math.max(0, Math.min(1, (+programData.loopStartPct / 100))) : 0.15),
+      posLoopEnd: Number.isFinite(+programData.posLoopEnd)
+        ? Math.max(0, Math.min(1, +programData.posLoopEnd))
+        : (Number.isFinite(+programData.loopEndPct) ? Math.max(0, Math.min(1, (+programData.loopEndPct / 100))) : 0.9),
+      posRelease: Number.isFinite(+programData.posRelease) ? Math.max(0, Math.min(1, +programData.posRelease)) : 1,
       loopStartPct: Number.isFinite(+programData.loopStartPct) ? +programData.loopStartPct : 15,
       loopEndPct: Number.isFinite(+programData.loopEndPct) ? +programData.loopEndPct : 90,
       sustainPct: Number.isFinite(+programData.sustainPct) ? +programData.sustainPct : 72,


### PR DESCRIPTION
### Motivation
- Provide a visual 4‑point editor and new playback state logic so the Tousky sampler can start at a Key Action point, sustain in a defined loop zone, and exit smoothly to a Release point on note‑up.
- Keep existing pitch/root detection and piano‑mapping behavior unchanged while adding normalized positional parameters for more precise program persistence.

### Description
- Add UI controls and color legend in `Main/index.html` and draw four vertical markers on the waveform for `Key Action` (violet), `Start Loop` (yellow), `End Loop` (red) and `Release` (blue). 
- Introduce normalized float variables (`posAction`, `posLoopStart`, `posLoopEnd`, `posRelease` in range `0.0–1.0`) and helper functions in `Main/sampler.js` to read, validate and display marker positions and to persist them when saving programs.
- Extend `Main/sampleDirectory.js` program model to accept and normalize the new `pos*` fields while remaining backward compatible with legacy `%` fields (`loopStartPct`, `loopEndPct`).
- Replace the previous simple looping playback in `Main/inst_sampler_touski.js` with a segmented playback implementation that: starts playback at `Key Action` on note‑down, loops strictly between `Start Loop` and `End Loop` while held, and on note‑up continues from the current playhead position to the `Release` point then stops; a short crossfade is applied when switching from sustain → release to reduce clicks.

### Testing
- Ran syntax checks with `node --check Main/sampler.js && node --check Main/inst_sampler_touski.js && node --check Main/sampleDirectory.js`, which succeeded.
- Verified that `node --check` including `Main/index.html` fails as expected because Node does not accept `.html` files for syntax checking.
- Attempted a headless UI capture via Playwright (served `Main/` over `python -m http.server`), but the Chromium process crashed (SIGSEGV) in this environment so screenshot validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6777ecd0832ebaa24db2348bcc5a)