### PR TITLE
Add Sample Tousky program library and improve waveform marker precision

### DIFF
--- a/Main/index.html
+++ b/Main/index.html
@@ -529,12 +529,22 @@
               <label class="small">Nom du programme
                 <input id="samplerProgramName" type="text" placeholder="Kick Punchy, Bass Warm..." style="width:100%;margin-top:6px">
               </label>
-              <label class="small">Programmes enregistrés
-                <select id="samplerProgramSelect" style="width:100%;margin-top:6px"></select>
+              <label class="small">Catégorie (sous-dossier)
+                <select id="samplerProgramCategory" style="width:100%;margin-top:6px"></select>
               </label>
             </div>
+            <label class="small" style="display:block;margin-top:8px">Nouveau sous-dossier
+              <div style="display:flex;gap:8px;margin-top:6px;align-items:center">
+                <input id="samplerProgramNewCategory" type="text" placeholder="ex: Keys/Bright" style="flex:1;min-width:180px">
+                <button class="btn2" id="samplerProgramCreateCategory">+ Créer</button>
+              </div>
+            </label>
+            <label class="small" style="display:block;margin-top:8px">Programmes enregistrés
+              <select id="samplerProgramSelect" style="width:100%;margin-top:6px"></select>
+            </label>
             <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">
-              <button class="btn2" id="samplerProgramSave">💾 Enregistrer le paramétrage</button>
+              <button class="btn2" id="samplerProgramUpdate">📝 Mettre à jour</button>
+              <button class="btn2" id="samplerProgramSaveAs">💾 Enregistrer sous</button>
               <button class="btn2" id="samplerProgramLoad">↩ Charger le programme</button>
             </div>
             <div class="small" id="samplerProgramStatus" style="margin-top:8px">Aucun programme enregistré.</div>

--- a/Main/inst_sampler_touski.js
+++ b/Main/inst_sampler_touski.js
@@ -25,7 +25,8 @@
     }
     return programs.map((p) => {
       const note = Number.isFinite(+p.rootMidi) ? midiToName(+p.rootMidi) : "—";
-      return { value: String(p.id), label: `${p.name} • ${note}` };
+      const cat = p.category ? `[${p.category}] ` : "";
+      return { value: String(p.id), label: `${cat}${p.name} • ${note}` };
     });
   }
 

--- a/Main/instrumentPanel.js
+++ b/Main/instrumentPanel.js
@@ -236,7 +236,7 @@ function renderInstrumentPanel(){
 
 if(!window.__samplerProgramPanelRefreshHook){
   window.__samplerProgramPanelRefreshHook = true;
-  window.addEventListener("sampler-programs:changed", ()=>{
-    try{ renderInstrumentPanel(); }catch(_){ }
-  });
+  const refresh = ()=>{ try{ renderInstrumentPanel(); }catch(_){ } };
+  window.addEventListener("sampler-programs:changed", refresh);
+  window.addEventListener("sampler-directory:change", refresh);
 }

--- a/Main/main.js
+++ b/Main/main.js
@@ -205,6 +205,11 @@ ipcMain.handle("project:load", async () => {
 // SAMPLER LIBRARY
 // -----------------------------------------------------------------------------
 const SUPPORTED_SAMPLE_EXTENSIONS = new Set([".wav", ".mp3", ".ogg"]);
+const PROGRAM_FILE_EXT = ".slsprog.json";
+
+function samplerProgramsRoot() {
+  return path.join(app.getPath("documents"), "Sl studio", "sampleTouski");
+}
 
 async function scanSamplerDirectory(rootDir) {
   const files = [];
@@ -275,4 +280,100 @@ ipcMain.handle("sampler:scanDirectories", async (_evt, payload = {}) => {
   }
 
   return { ok: true, roots: indexed };
+});
+
+async function ensureSamplerProgramsRoot() {
+  const root = samplerProgramsRoot();
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+async function scanProgramsTree(rootDir) {
+  const programs = [];
+
+  async function walk(currentDir) {
+    let entries = [];
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch (_error) {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.toLowerCase().endsWith(PROGRAM_FILE_EXT)) continue;
+      try {
+        const raw = await fs.readFile(fullPath, "utf-8");
+        const parsed = JSON.parse(raw);
+        programs.push({
+          ...parsed,
+          id: parsed.id || path.relative(rootDir, fullPath).replace(/\\/g, "/"),
+          filePath: fullPath,
+          relativeFilePath: path.relative(rootDir, fullPath).replace(/\\/g, "/"),
+          category: path.dirname(path.relative(rootDir, fullPath)).replace(/\\/g, "/") || "",
+        });
+      } catch (error) {
+        console.warn("[Sampler] invalid program file", fullPath, error?.message || error);
+      }
+    }
+  }
+
+  await walk(rootDir);
+  programs.sort((a, b) => String(a.relativeFilePath).localeCompare(String(b.relativeFilePath)));
+  return programs;
+}
+
+ipcMain.handle("sampler:listPrograms", async () => {
+  const root = await ensureSamplerProgramsRoot();
+  const programs = await scanProgramsTree(root);
+  return { ok: true, rootPath: root, programs };
+});
+
+ipcMain.handle("sampler:createCategory", async (_evt, payload = {}) => {
+  const root = await ensureSamplerProgramsRoot();
+  const rel = String(payload.relativeDir || "").trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const target = path.resolve(root, rel || ".");
+  if (!target.startsWith(path.resolve(root))) return { ok: false, error: "Chemin invalide" };
+  await fs.mkdir(target, { recursive: true });
+  return { ok: true, relativeDir: rel };
+});
+
+ipcMain.handle("sampler:saveProgram", async (_evt, payload = {}) => {
+  const root = await ensureSamplerProgramsRoot();
+  const program = payload.program && typeof payload.program === "object" ? payload.program : null;
+  if (!program) return { ok: false, error: "Programme invalide" };
+
+  const mode = payload.mode === "update" ? "update" : "saveAs";
+  const relativeDir = String(payload.relativeDir || "").trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const cleanName = String(program.name || "Sampler Program").trim().replace(/[<>:"/\\|?*\x00-\x1F]/g, "_");
+  const fileName = `${cleanName || "Sampler Program"}${PROGRAM_FILE_EXT}`;
+
+  let outFile = "";
+  if (mode === "update" && payload.targetFilePath) {
+    const requested = path.resolve(String(payload.targetFilePath));
+    if (requested.startsWith(path.resolve(root))) outFile = requested;
+  }
+  if (!outFile) {
+    const dir = path.resolve(root, relativeDir || ".");
+    if (!dir.startsWith(path.resolve(root))) return { ok: false, error: "Dossier invalide" };
+    await fs.mkdir(dir, { recursive: true });
+    outFile = path.join(dir, fileName);
+  }
+
+  const toWrite = {
+    ...program,
+    updatedAt: new Date().toISOString(),
+    category: path.dirname(path.relative(root, outFile)).replace(/\\/g, "/") || "",
+  };
+  await fs.writeFile(outFile, JSON.stringify(toWrite, null, 2), "utf-8");
+  return {
+    ok: true,
+    rootPath: root,
+    filePath: outFile,
+    relativeFilePath: path.relative(root, outFile).replace(/\\/g, "/"),
+    program: toWrite,
+  };
 });

--- a/Main/preload.js
+++ b/Main/preload.js
@@ -12,4 +12,7 @@ contextBridge.exposeInMainWorld("audioNative", {
 contextBridge.exposeInMainWorld("samplerFS", {
   pickDirectories: () => ipcRenderer.invoke("sampler:pickDirectories"),
   scanDirectories: (directories) => ipcRenderer.invoke("sampler:scanDirectories", { directories }),
+  listPrograms: () => ipcRenderer.invoke("sampler:listPrograms"),
+  createCategory: (relativeDir) => ipcRenderer.invoke("sampler:createCategory", { relativeDir }),
+  saveProgram: (payload) => ipcRenderer.invoke("sampler:saveProgram", payload),
 });

--- a/Main/sampler.js
+++ b/Main/sampler.js
@@ -24,8 +24,12 @@
   const modeReleaseBtn = document.getElementById("samplerModeRelease");
   const wizardLoopBtn = document.getElementById("samplerWizardLoop");
   const programNameEl = document.getElementById("samplerProgramName");
+  const programCategoryEl = document.getElementById("samplerProgramCategory");
+  const programNewCategoryEl = document.getElementById("samplerProgramNewCategory");
+  const programCreateCategoryBtn = document.getElementById("samplerProgramCreateCategory");
   const programSelectEl = document.getElementById("samplerProgramSelect");
-  const programSaveBtn = document.getElementById("samplerProgramSave");
+  const programUpdateBtn = document.getElementById("samplerProgramUpdate");
+  const programSaveAsBtn = document.getElementById("samplerProgramSaveAs");
   const programLoadBtn = document.getElementById("samplerProgramLoad");
   const programStatusEl = document.getElementById("samplerProgramStatus");
 
@@ -328,6 +332,15 @@
     drawWaveform(analysisState.buffer);
   }
 
+
+  function eventToCanvasX(event) {
+    if (!waveCanvas) return 0;
+    const rect = waveCanvas.getBoundingClientRect();
+    if (!rect.width) return 0;
+    const ratio = (event.clientX - rect.left) / rect.width;
+    return clamp01(ratio) * waveCanvas.width;
+  }
+
   function markerFromCanvasX(x, thresholdPx = 9) {
     const candidates = ["pos_action", "pos_loop_start", "pos_loop_end", "pos_release"];
     for (const key of candidates) {
@@ -349,7 +362,7 @@
         const nextAmp = viewState.ampZoom * (direction > 0 ? 0.9 : 1.1);
         viewState.ampZoom = Math.max(0.35, Math.min(8, nextAmp));
       } else {
-        const pivot = canvasXToNorm(event.offsetX);
+        const pivot = canvasXToNorm(eventToCanvasX(event));
         const currentRange = viewState.end - viewState.start;
         const nextRange = Math.max(0.01, Math.min(1, currentRange * (direction > 0 ? 1.08 : 0.92)));
         const anchor = clamp01((pivot - viewState.start) / currentRange);
@@ -372,13 +385,14 @@
       }
       if (event.button !== 0) return;
 
-      const marker = markerFromCanvasX(event.offsetX);
+      const clickX = eventToCanvasX(event);
+      const marker = markerFromCanvasX(clickX);
       if (marker) {
         viewState.draggingMarker = marker;
         drawWaveform(analysisState.buffer);
         return;
       }
-      placeMarkerFromCanvasX(event.offsetX);
+      placeMarkerFromCanvasX(clickX);
     });
 
     waveCanvas.addEventListener("mousemove", (event) => {
@@ -386,7 +400,8 @@
       if (viewState.isPanning) {
         const range = viewState.end - viewState.start;
         if (range >= 0.999) return;
-        const deltaNorm = (event.clientX - viewState.panAnchorX) / waveCanvas.width;
+        const rect = waveCanvas.getBoundingClientRect();
+        const deltaNorm = (event.clientX - viewState.panAnchorX) / Math.max(1, rect.width);
         let nextStart = viewState.panStartView - deltaNorm * range;
         nextStart = Math.max(0, Math.min(1 - range, nextStart));
         viewState.start = nextStart;
@@ -396,7 +411,7 @@
       }
       if (!viewState.draggingMarker) return;
       const data = analysisState.buffer.getChannelData(0);
-      const raw = canvasXToNorm(event.offsetX);
+      const raw = canvasXToNorm(eventToCanvasX(event));
       const idx = Math.floor(clamp01(raw) * (data.length - 1));
       const snapped = nearestZeroCrossing(data, idx);
       setMarkerPositions({ [viewState.draggingMarker]: snapped / Math.max(1, data.length - 1) });
@@ -638,7 +653,7 @@
     analyzeImportedSample(imported);
   }
 
-  function toProgramPayload(sample, sourceProgramId = null) {
+  function toProgramPayload(sample, sourceProgram = null) {
     const rootMidiFromUI = Number.parseInt(String(rootNoteEl?.textContent || "").match(/MIDI\s*(-?\d+)/)?.[1] || "", 10);
     const rootHzFromUI = Number.parseFloat(String(rootHzEl?.textContent || "").match(/([\d.]+)\s*Hz/)?.[1] || "");
     const suggestedName = sampleSuggestedProgramName(sample) || "Sampler Program";
@@ -646,7 +661,10 @@
     const positions = getMarkerPositions();
 
     return {
-      id: sourceProgramId || undefined,
+      id: sourceProgram?.id || undefined,
+      filePath: sourceProgram?.filePath || null,
+      relativeFilePath: sourceProgram?.relativeFilePath || null,
+      category: programCategoryEl?.value || sourceProgram?.category || "",
       name: rawName || suggestedName,
       sample: sample || null,
       rootMidi: Number.isFinite(analysisState?.rootMidi) ? analysisState.rootMidi : (Number.isFinite(rootMidiFromUI) ? rootMidiFromUI : null),
@@ -659,6 +677,27 @@
       loopEndPct: Math.round(positions.pos_loop_end * 100),
       sustainPct: Math.round(positions.pos_loop_end * 100),
     };
+  }
+
+
+  function renderCategories(snapshot) {
+    if (!programCategoryEl) return;
+    const categories = Array.isArray(snapshot.categories) ? snapshot.categories : [""];
+    const selected = snapshot.activeCategory || "";
+    programCategoryEl.innerHTML = "";
+    for (const cat of categories) {
+      const opt = document.createElement("option");
+      opt.value = cat;
+      opt.textContent = cat || "(racine)";
+      programCategoryEl.appendChild(opt);
+    }
+    if (!categories.includes(selected)) {
+      const extra = document.createElement("option");
+      extra.value = selected;
+      extra.textContent = selected || "(racine)";
+      programCategoryEl.appendChild(extra);
+    }
+    programCategoryEl.value = selected;
   }
 
   function renderPrograms(snapshot) {
@@ -694,7 +733,9 @@
     }
     if (activeProgram) {
       const sampleName = activeProgram.sample?.relativePath || activeProgram.sample?.name || "sample non défini";
-      setProgramStatus(`Programme actif: ${activeProgram.name || "Sampler Program"} • ${sampleName}`);
+      const where = activeProgram.relativeFilePath || activeProgram.category || "(racine)";
+      if (programCategoryEl && activeProgram.category != null) programCategoryEl.value = activeProgram.category || "";
+      setProgramStatus(`Programme actif: ${activeProgram.name || "Sampler Program"} • ${sampleName} • ${where}`);
     }
   }
 
@@ -703,6 +744,7 @@
     renderBrowser(snapshot);
     renderPreview(snapshot);
     renderImported(snapshot);
+    renderCategories(snapshot);
     renderPrograms(snapshot);
   }
 
@@ -791,21 +833,50 @@
     directory.setActiveProgram(id || null);
   });
 
-  programSaveBtn?.addEventListener("click", () => {
+  async function saveProgramWithMode(mode) {
     const imported = directory.state.importedSample;
     if (!imported) {
       setProgramStatus("Importez d'abord un sample avant d'enregistrer un programme.");
       return;
     }
 
-    const payload = toProgramPayload(imported, programSelectEl?.value || null);
-    const result = directory.saveProgram(payload);
+    const current = directory.getProgram(programSelectEl?.value || null);
+    const payload = toProgramPayload(imported, current);
+    const opts = {
+      mode,
+      relativeDir: programCategoryEl?.value || "",
+      targetFilePath: mode === "update" ? current?.filePath : null,
+    };
+    const result = await directory.saveProgram(payload, opts);
     if (!result?.ok) {
       setProgramStatus(`Erreur sauvegarde programme: ${result?.error || "inconnue"}`);
       return;
     }
-    setProgramStatus(`Programme sauvegardé: ${result.program.name}`);
-    global.dispatchEvent(new CustomEvent("sampler-programs:changed", { detail: result.program }));
+    setProgramStatus(`Programme sauvegardé: ${result.program?.name || payload.name}`);
+    global.dispatchEvent(new CustomEvent("sampler-programs:changed", { detail: result.program || payload }));
+  }
+
+  programUpdateBtn?.addEventListener("click", () => saveProgramWithMode("update"));
+  programSaveAsBtn?.addEventListener("click", () => saveProgramWithMode("saveAs"));
+
+
+  programCategoryEl?.addEventListener("change", () => {
+    directory.setActiveCategory(programCategoryEl.value || "");
+  });
+
+  programCreateCategoryBtn?.addEventListener("click", async () => {
+    const value = String(programNewCategoryEl?.value || "").trim();
+    if (!value) {
+      setProgramStatus("Entrez un nom de sous-dossier.");
+      return;
+    }
+    const result = await directory.createCategory(value);
+    if (!result?.ok) {
+      setProgramStatus(`Erreur création dossier: ${result?.error || "inconnue"}`);
+      return;
+    }
+    if (programNewCategoryEl) programNewCategoryEl.value = "";
+    setProgramStatus(`Catégorie prête: ${result.relativeDir || "(racine)"}`);
   });
 
   programLoadBtn?.addEventListener("click", () => {


### PR DESCRIPTION
### Motivation
- Provide a disk-backed, user-manageable library for Sampler Tousky programs with folders/categories and explicit save/update workflows so users can organize and persist Sample + Mapping + control points in `Documents/Sl studio/sampleTouski`.
- Fix waveform marker placement inaccuracies by making mouse-to-canvas coordinate conversion respect the canvas viewport, zoom and pan so markers (Action/Start/End/Release) land on the intended sample index.
- Allow per-instance program navigation and faster UI refresh for sampler programs so each piano-roll instance can quickly load a program without interference.

### Description
- Added a program library backend and IPC: `sampler:listPrograms`, `sampler:createCategory`, and `sampler:saveProgram` in `Main/main.js`, using `.slsprog.json` files under `Documents/Sl studio/sampleTouski` and recursive scanning/writing logic.
- Exposed the new APIs in the renderer via `preload.js` (`window.samplerFS.listPrograms`, `createCategory`, `saveProgram`) and extended `sampleDirectory` to refresh programs from disk, track categories, and auto-refresh periodically (`Main/sampleDirectory.js`).
- Updated the Sampler UI (`Main/index.html` + `Main/sampler.js`) with category selection, new-category creation, and `Mettre à jour` / `Enregistrer sous` actions and implemented `eventToCanvasX` + adjusted pan math so mouse clicks/moves/scrolls map correctly to buffer indices when zoomed/panned.
- Updated instrument-side UX so instances show categories in program lists and the instrument panel refreshes on library or directory changes (`Main/inst_sampler_touski.js`, `Main/instrumentPanel.js`).

### Testing
- Ran syntax checks with `node --check` on `Main/main.js`, `Main/preload.js`, `Main/sampleDirectory.js`, `Main/sampler.js`, `Main/instrumentPanel.js`, and `Main/inst_sampler_touski.js`, and they succeeded.
- Exercised the UI by serving `Main/` via a simple HTTP server and running a Playwright script that opened the Sampler tab and saved a screenshot; a screenshot artifact was produced at the Playwright run (artifact path shown in CI output).
- No automated unit tests were present; the changes were validated via the static checks and the headless UI screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f35ed8d0c832e94042729fb9ec197)