### PR TITLE
Fix Sampler Touski program ID collisions by using stable file-path IDs

### DIFF
--- a/Main/sampler.js
+++ b/Main/sampler.js
@@ -653,7 +653,7 @@
     analyzeImportedSample(imported);
   }
 
-  function toProgramPayload(sample, sourceProgram = null) {
+  function toProgramPayload(sample, sourceProgram = null, mode = "saveAs") {
     const rootMidiFromUI = Number.parseInt(String(rootNoteEl?.textContent || "").match(/MIDI\s*(-?\d+)/)?.[1] || "", 10);
     const rootHzFromUI = Number.parseFloat(String(rootHzEl?.textContent || "").match(/([\d.]+)\s*Hz/)?.[1] || "");
     const suggestedName = sampleSuggestedProgramName(sample) || "Sampler Program";
@@ -661,7 +661,7 @@
     const positions = getMarkerPositions();
 
     return {
-      id: sourceProgram?.id || undefined,
+      id: mode === "update" ? (sourceProgram?.id || undefined) : undefined,
       filePath: sourceProgram?.filePath || null,
       relativeFilePath: sourceProgram?.relativeFilePath || null,
       category: programCategoryEl?.value || sourceProgram?.category || "",
@@ -841,7 +841,7 @@
     }
 
     const current = directory.getProgram(programSelectEl?.value || null);
-    const payload = toProgramPayload(imported, current);
+    const payload = toProgramPayload(imported, current, mode);
     const opts = {
       mode,
       relativeDir: programCategoryEl?.value || "",


### PR DESCRIPTION
### Motivation
- `Save As` could reuse an existing program `id`, producing duplicate IDs and causing selection jumps and cross-instance interference in the Sampler Touski UI.
- Program listing and category resolution must rely on a stable identifier so each saved `.slsprog.json` maps consistently to one program entry.

### Description
- In `Main/main.js` the program scanner now computes a `relativeFilePath` and uses it as a stable `id` when building program objects returned by `scanProgramsTree` and when deriving `category`.
- In `Main/main.js` the `sampler:saveProgram` handler now sets `id` to the program file's `relativeFilePath` before writing the `.slsprog.json` file and returns that `relativeFilePath` in the IPC response.
- In `Main/sampler.js` `toProgramPayload` now accepts a `mode` parameter and only preserves the source `id` when `mode === "update"`, and callers were updated to pass the current save mode so `Save As` does not reuse the old ID.

### Testing
- Ran `node --check Main/main.js` which completed successfully.
- Ran `node --check Main/sampler.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4a1d1a08832e95821cf14c519345)